### PR TITLE
Avoid syncing .svn subfolder

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -93,6 +93,9 @@ define selinux::module(
 
       file { $this_module_dir:
         ensure  => directory,
+        source  => $sourcedir,
+        recurse => remote,
+        ignore  => '.svn',
       }
 
       file { "${this_module_dir}/${name}.te":


### PR DESCRIPTION
We have our Puppet configuration in Subversion, which creates .svn folders everywhere. This selinux module was syncing our .svn folder along with the .te file we actually want copied. I removed the lines that sync the entire folder recursively, and it seems to work.

Is this change correct? What might be the negative side effects?
