### PR TITLE
Completely empty/unavailable $::selinux fact means no SELinux.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,6 +36,7 @@ class selinux::config(
 
   $current_mode = $::selinux? {
     'false' => 'disabled',
+    ''      => 'disabled',
     default => $::selinux_current_mode
   }
   # we don't always run setenforce


### PR DESCRIPTION
I have few RHEL machines with completely disabled SELinux and latest facter fails on $::selinux get:

```
# sestatus 
SELinux status:                 disabled
# facter selinux
Could not retrieve selinux: Invalid argument - /proc/self/attr/current
```

That means the fact $::selinux is later unavailable in Puppet and we should behave same way as if we get "false" status.
