### PR TITLE
RH release version comparison

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class selinux::params (
   ) {
   case $::osfamily {
     'RedHat': {
-      if $::operatingsystemrelease < '7' {
+      if versioncmp($::operatingsystemrelease, '7') < 0 {
         $selinux_policy_devel = 'selinux-policy'
       } else {
         $selinux_policy_devel = 'selinux-policy-devel'


### PR DESCRIPTION
New CentOS 7 can contain version information consisted of three components

```
# facter | grep -i 7.0.1406
lsbdistdescription => CentOS Linux release 7.0.1406 (Core) 
lsbdistrelease => 7.0.1406
operatingsystemrelease => 7.0.1406
```

and current simple check `$::operatingsystemrelease < '7'` fails on Puppet error `"Error: comparison of String with 7 failed at"`. Function **versioncmp** is better for version comparisons.
