### PR TITLE
Add a parameter to suppress reboot notify resource

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -55,6 +55,11 @@ class { 'selinux':
    make is required to install modules. If you have the make package declared
    elsewhere, you want to set this to false. It defaults to true.
 
+- *quiet_reboot_notify*
+  
+  In the case of going from {enabled|permissive} -> disabled or back, suppress
+  the notify resource and write notification to the log instead.
+
 ## selinux::module
 <pre>
 selinux::module { 'rsynclocal':

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,7 +16,8 @@
 #  This module should not be called directly.
 #
 class selinux::config(
-  $mode
+  $mode,
+  $quiet_reboot_notify,
 ) {
   Exec {
     path => '/bin:/sbin:/usr/bin:/usr/sbin',
@@ -52,8 +53,13 @@ class selinux::config(
       'disabled': {
         # we can't apply right now disabled, but we can set it to permissive
         $change = "from ${current_mode} to ${real_mode}"
-        notify { 'change':
-          message => "A reboot is required to change ${change}"
+        if $quiet_reboot_notify {
+          notice("A reboot is required to change ${change}")
+        }
+        else {
+          notify { 'change':
+            message => "A reboot is required to change ${change}"
+          }
         }
         if $current_mode == 'enforcing' {
           exec { 'setenforce permissive':
@@ -65,8 +71,13 @@ class selinux::config(
         if $current_mode == 'disabled' {
           # we can't set disabled now, it needs a reboot.
           $change = "from ${current_mode} to ${real_mode}"
-          notify { 'change':
-            message => "A reboot is required to change ${change}"
+          if $quiet_reboot_notify {
+            notice("A reboot is required to change ${change}")
+          }
+          else {
+            notify { 'change':
+              message => "A reboot is required to change ${change}"
+            }
           }
         } else {
           # we're going from permissive to enforcing or vice-versa

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,8 +19,9 @@
 #  include selinux
 #
 class selinux(
-  $mode         = 'enforcing',
-  $installmake  = true,
+  $mode                = 'enforcing',
+  $installmake         = true,
+  $quiet_reboot_notify = false,
   ) {
   include selinux::params
 
@@ -32,6 +33,7 @@ class selinux(
   }
 
   class { 'selinux::config':
-      mode => $mode,
+      mode                => $mode,
+      quiet_reboot_notify => $quiet_reboot_notify,
   }
 }


### PR DESCRIPTION
A fix for https://github.com/spiette/puppet-selinux/issues/17

Basically allow the "reboot required" notification to be suppressed down into the debug log.
