### PR TITLE
Fix EL7 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,10 +10,10 @@
 #
 class selinux::params (
   $modules_dir = "${::settings::vardir}/selinux"
-  ) {
+) {
   case $::osfamily {
     'RedHat': {
-      if $::operatingsystemrelease < '7' {
+      if versioncmp($::operatingsystemrelease, '7.0.0') < 0 {
         $selinux_policy_devel = 'selinux-policy'
       } else {
         $selinux_policy_devel = 'selinux-policy-devel'


### PR DESCRIPTION
Starting with EL7 $::operatingsystemrelease is no longer an integer but a full blown version string.

```
# facter operatingsystemrelease
7.0.1406
```
