### PR TITLE
Update params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,11 +13,11 @@ class selinux::params (
   ) {
   case $::osfamily {
     'RedHat': {
-      if $::operatingsystemrelease < '7' {
+      if $::::operatingsystemmajrelease < '7' {
         $selinux_policy_devel = 'selinux-policy'
       } else {
         $selinux_policy_devel = 'selinux-policy-devel'
-      }
+     } 
     }
     default: {
         fail('Unsupported OS')


### PR DESCRIPTION
The error:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: comparison of String with 7 failed at /etc/puppet/environments/production/modules/selinux/manifests/params.pp:16 on node compute-0-04.cloud.epfl.ch
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

CentOS 7.1:

```
[root@compute-0-04 ~]# cat /etc/redhat-release
CentOS Linux release 7.1.1503 (Core)
```

Facts:

```
[root@compute-0-04 ~]# facter
[...]
operatingsystem => CentOS
operatingsystemmajrelease => 7
operatingsystemrelease => 7.1.1503
```

Hack:
operatingsystemrelease -> operatingsystemmajrelease and the test pass.
