### PR TITLE
Use $::puppet_vardir instead of $::settings::vardir

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@
 # }
 #
 class selinux::params (
-  $modules_dir = "${::settings::vardir}/selinux"
+  $modules_dir = "${::puppet_vardir}/selinux"
   ) {
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
$::settings::vardir resolves to the puppetmaster's vardir.
$::puppet_vardir is a fact that rsolves to the clients's vardir.  In
this case, since we're putting the config on the client, we want to use
the client's vardir.
