### PR TITLE
Different osrelease comparison depending on the puppet version 

### DIFF
--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -67,6 +67,7 @@ describe 'selinux::module', :type => :define do
       modname = 'rsynclocal'
       source = "puppet:///modules/selinux/#{modname}"
       modules_dir = '/var/lib/puppet/selinux'
+      #let(:parser) {'future' }
       let(:title) { modname }
       let(:params) {{
         :source      => source,
@@ -76,7 +77,16 @@ describe 'selinux::module', :type => :define do
           :osfamily      => 'RedHat',
           :operatingsystemrelease => osrelease,
       } }
-      if osrelease.to_f < 7
+      
+      osrelease_newer_than_seven = true
+
+      if Puppet::version < "4"
+        osrelease_newer_than_seven = (osrelease.to_f < 7)
+      else
+        osrelease_newer_than_seven = (osrelease < '7')
+      end
+
+      if osrelease_newer_than_seven
         it { should create_package('selinux-policy') }
       else
         it { should create_package('selinux-policy-devel') }


### PR DESCRIPTION
Different `osrelease` comparison depending on the puppet version in the `selinux_module_spec`
