### PR TITLE
switch to $::operatingsystemmajrelease

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class selinux::params (
   ) {
   case $::osfamily {
     'RedHat': {
-      if $::operatingsystemrelease < '7' {
+      if $::operatingsystemmajrelease < '7' {
         $selinux_policy_devel = 'selinux-policy'
       } else {
         $selinux_policy_devel = 'selinux-policy-devel'


### PR DESCRIPTION
operatingsystemrelease doesn't work any longer at least on puppet 3.8.7/CentOS 7